### PR TITLE
#16 맞수수 프론트 API 호출부 수정

### DIFF
--- a/src/apis/HandGameAPICalls.js
+++ b/src/apis/HandGameAPICalls.js
@@ -7,41 +7,10 @@ export const callGetWordsAPI = (difficulty, totalQuestion) => {
         try {
             const queryString = `difficulty=${difficulty}&totalQuestion=${totalQuestion}`;
 
-            // const result = await request(
-            //     'GET',
-            //     `/get-words?${queryString}`
-            // );
-
-            const result = {
-                status: 200,
-                data: [
-                    {
-                        riddleId: 1,        // 문제 식별 번호
-                        question: '바나나',  // 문제(단어) 이름
-                        totalStep: 2        // 문제의 step 개수
-                    },
-                    {
-                        riddleId: 4,
-                        question: '안녕하세요',
-                        totalStep: 3
-                    },
-                    {
-                        riddleId: 6,
-                        question: '금연',
-                        totalStep: 3
-                    },
-                    {
-                        riddleId: 5,
-                        question: '빵집',
-                        totalStep: 2
-                    },
-                    {
-                        riddleId: 9,
-                        question: '소방관',
-                        totalStep: 4
-                    },
-                ]
-            }
+            const result = await request(
+                'GET',
+                `/api/v1/sign/game-start?${queryString}`
+            );
 
             console.log('callGetWordsAPI result : ', result.data);
 
@@ -59,24 +28,12 @@ export const callGetWordsAPI = (difficulty, totalQuestion) => {
 export const callGetWordImageAPI = (riddleId, currentStep) => {
     return async (dispatch, getState) => {
         try {
-            const requestData = {
-                riddleId: riddleId,
-                step: currentStep
-            };
+            const queryString = `riddleId=${riddleId}&step=${currentStep}`;
 
-            // const result = await request(
-            //     'POST',
-            //     `/gameStart`,
-            //     'Content-Type: application/x-www-form-urlencoded',
-            //     requestData
-            // );
-
-            const result = {
-                status: 200,
-                data: {
-                    guide: '/images/no_smoking_2.png'
-                }
-            }
+            const result = await request(
+                'GET',
+                `/api/v1/sign/question-image?${queryString}`
+            );
 
             console.log('callGetWordImageAPI result : ', result);
 
@@ -95,19 +52,13 @@ export const callGetWordImageAPI = (riddleId, currentStep) => {
 export const callGetWordVideoAPI = (riddleId) => {
     return async (dispatch, getState) => {
         try {
-            const queryString = `wordDes=${riddleId}`;
+            const queryString = `riddleId=${riddleId}`;
 
-            // const result = await request(
-            //     'GET',
-            //     `/get-video-link?${queryString}`
-            // );
+            const result = await request(
+                'GET',
+                `/api/v1/sign/question-video?${queryString}`
+            );
 
-            const result = {
-                status: 200,
-                data: {
-                    videoLink: 'http://sldict.korean.go.kr/multimedia/multimedia_files/convert/20200821/732937/MOV000257072_700X466.mp4'
-                }
-            }
             console.log('callGetWordVideoAPI result : ', result);
 
             if (result.status === 200) {

--- a/src/apis/api.js
+++ b/src/apis/api.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const SERVER_IP = `localhost`;
-const SERVER_PORT = `8000`;
+const SERVER_PORT = `8080`;
 const DEFAULT_URL = `http://${SERVER_IP}:${SERVER_PORT}`;
 
 export const request = async (method, url, headers, data) => {

--- a/src/components/button/DifficultyButton.js
+++ b/src/components/button/DifficultyButton.js
@@ -8,20 +8,20 @@ function DifficultyButton({difficulty, handleDifficulty}) {
             <Flex flexDirection="column">
                 <HStack spacing={2} justify="center">
                     <Button w="80px" h="32px" fontSize={14} fontWeight={500}
-                            value="easy" onClick={handleDifficulty}
-                            variant={difficulty === 'easy' ? 'mint' : 'gray'}
+                            value="LEVEL_1" onClick={handleDifficulty}
+                            variant={difficulty === 'LEVEL_1' ? 'mint' : 'gray'}
                     >
                         쉬움
                     </Button>
                     <Button w="80px" h="32px" fontSize={14} fontWeight={500}
-                            value="medium" onClick={handleDifficulty}
-                            variant={difficulty === 'medium' ? 'mint' : 'gray'}
+                            value="LEVEL_2" onClick={handleDifficulty}
+                            variant={difficulty === 'LEVEL_2' ? 'mint' : 'gray'}
                     >
                         보통
                     </Button>
                     <Button w="80px" h="32px" fontSize={14} fontWeight={500}
-                            value="hard" onClick={handleDifficulty}
-                            variant={difficulty === 'hard' ? 'mint' : 'gray'}
+                            value="LEVEL_3" onClick={handleDifficulty}
+                            variant={difficulty === 'LEVEL_3' ? 'mint' : 'gray'}
                     >
                         어려움
                     </Button>

--- a/src/modules/HandGameReducer.js
+++ b/src/modules/HandGameReducer.js
@@ -18,7 +18,7 @@ const UPDATE_CORRECT = 'game/UPDATE_CORRECT';
 
 export const { game : {getWords, getWordImage, getWordVideo, checkCorrect, resetCorrect, updateCorrect}} = createActions({
     [GET_WORDS] : result => ({ questionList : result.data }),
-    [GET_WORD_IMAGE] : result => ({ wordImage : result.data.guide }),
+    [GET_WORD_IMAGE] : result => ({ wordImage : result.data }),
     [GET_WORD_VIDEO] : result => ({ wordVideo : result.data }),
     [CHECK_CORRECT] : result => ({ isCorrect : result.data.isCorrect }),
     [RESET_CORRECT] : result => ({ isCorrect : null }),

--- a/src/pages/hand/HandGameInfo.js
+++ b/src/pages/hand/HandGameInfo.js
@@ -5,7 +5,7 @@ import HandGamePage from "./HandGamePage";
 
 function HandGameInfo() {
     const [isGameStarted, setIsGameStarted] = useState(false);
-    const [difficulty, setDifficulty] = useState("easy");
+    const [difficulty, setDifficulty] = useState("LEVEL_1");
 
     const handleStartGame = () => {
         setIsGameStarted(true);

--- a/src/pages/hand/HandGamePage.js
+++ b/src/pages/hand/HandGamePage.js
@@ -17,7 +17,7 @@ import HandGameFinish from "./HandGameFinish";
 function HandGamePage({difficulty, onQuitGame}) {
 
     const [gameInfo, setGameInfo] = useState({
-        totalQuestion: 5,       // 총 문제 개수
+        totalQuestion: 3,       // 총 문제 개수
         currentQuestion: 0,     // 현재 문제 순번
         currentStep: 1,         // 현재 문제의 Step
         correctedAnswer: 0,     // 정답 개수
@@ -55,10 +55,6 @@ function HandGamePage({difficulty, onQuitGame}) {
             reset();
         }
     }, [isCorrect, dispatch]);
-
-    useEffect(() => {
-
-    }, [isGameFinished, dispatch]);
 
     const nextStep = () => {
         setGameInfo({

--- a/src/pages/hand/HandGameQuestion.js
+++ b/src/pages/hand/HandGameQuestion.js
@@ -17,7 +17,7 @@ function HandGameQuestion({gameInfo, questionList, webcam, capturedImage, countd
 
     useEffect(() => {
         dispatch(callGetWordImageAPI(questionList[gameInfo.currentQuestion].riddleId, gameInfo.currentStep));
-    }, [gameInfo.currentStep, dispatch]);
+    }, [gameInfo.currentStep, gameInfo.currentQuestion, dispatch]);
 
     return (
         <Box borderWidth='1px' borderRadius='lg' overflow='visible' position='relative' mt={4}>
@@ -66,6 +66,7 @@ function HandGameQuestion({gameInfo, questionList, webcam, capturedImage, countd
                            position="absolute"
                            top={0}
                            left={0}
+                           opacity={0.3}
                            width="100%"
                            height="100%"
                     />

--- a/src/pages/hand/SuccessModal.js
+++ b/src/pages/hand/SuccessModal.js
@@ -44,7 +44,7 @@ function SuccessModal({nextQuestion, isOpen, onClose, riddleId}) {
                         <Box
                             as='video'
                             controls
-                            src={wordVideo.videoLink}
+                            src={wordVideo}
                             objectFit='contain'
                             mt={8}
                             borderRadius='md'

--- a/src/pages/sound/SoundGameInfo.js
+++ b/src/pages/sound/SoundGameInfo.js
@@ -5,7 +5,7 @@ import SoundGamePage from "./SoundGamePage";
 
 function SoundGameInfo() {
     const [isGameStarted, setIsGameStarted] = useState(false);
-    const [difficulty, setDifficulty] = useState("easy");
+    const [difficulty, setDifficulty] = useState("LEVEL_1");
 
     // TODO: 컴포넌트 제대로 안 뽀개서, DifficultyButton에 맞수수 내용 들어가 있음 ㅎ
 

--- a/src/utils/DifficultyUtils.js
+++ b/src/utils/DifficultyUtils.js
@@ -1,8 +1,8 @@
 export const getDifficultyKor = (difficulty) => {
     switch (difficulty) {
-        case 'easy' : return "쉬움";
-        case 'medium' : return "보통";
-        case 'hard' : return "어려움";
+        case 'LEVEL_1' : return "쉬움";
+        case 'LEVEL_2' : return "보통";
+        case 'LEVEL_3' : return "어려움";
         default : return "쉬움";
     }
 }


### PR DESCRIPTION
<!-- --------------------------------------------------------- -->
<!-- 제목 작성 규칙✅ : #이슈번호 이슈명 -->
<!-- [예시] #23 로그인 페이지 추가 -->
<!-- --------------------------------------------------------- -->


### 📫 PR 유형
<!-- 하나 이상의 PR 타입을 선택해주세요. -->
<!-- 해당하는 유형의 [] 내부에 x를 적어주세요. 중복 기입 가능 -->
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 개요
<!-- 개요 작성 규칙✅ : PR 개요 및 이슈 번호를 입력하세요. --> 
<!-- 단, 종료된 이슈라면 closed #{이슈번호} 형태로 입력하세요. --> 
<!-- [예시] 🚀 #21 -->
> 맞수수 프론트의 API 호출부를 개발 진행된 BE에 맞도록 수정했어요.
- closed #16 

## 💻 작업 내용
- 임시 데이터로 작성되어 있던 API 호출부를 전부 실제 BE API 호출로 수정했어요.
- Difficulty의 value도 실제 DB의 GameDifficulty 값과 맞췄어요.
- 맞수수 guide image load를 트리거하는 의존성 배열에 currentQuestion을 추가했어요. (currentStep만으로는 일부 스킵 상황에서 새 이미지를 불러오지 못해요.)

## 📚 참고
<!-- (선택사항) 작성이 필요한 경우만 추가 -->


<!-- --------------------------------------------------------- -->
<!-- PR 작성 시 확인 목록✅ -->
<!-- 1) 이슈와 기능에 맞는 라벨(label) 선택 -->
<!-- 2) 프로젝트(project) 선택 -->
<!-- 3) 마일스톤(milestone)선택 -->
<!-- --------------------------------------------------------- -->
